### PR TITLE
Implement automatic retry for failed requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nixify",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Nixify is a tiny JavaScript HTTP client based on browser Fetch API.",
   "type": "module",
   "module": "@Nixify/index.js",

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -1,0 +1,15 @@
+import timeout from "../utils/timeout"
+
+const _fetch = async (request: Request, config) => {
+	if (config?.hooks?.beforeRequest) {
+		await config.hooks.beforeRequest(request)
+	}
+
+	if (config.timeout === false) {
+		return fetch(request.clone())
+	}
+
+	return timeout(request.clone(), config.abortController, config.timeout)
+}
+
+export default _fetch

--- a/src/core/fetchRetry.ts
+++ b/src/core/fetchRetry.ts
@@ -1,0 +1,67 @@
+import _fetch from "./fetch"
+import json from "../utils/json-parse"
+import { RequestInitRetryParams } from "../types"
+
+/**
+ * Based on https://github.com/jonbern/fetch-retry/blob/master/index.js
+ */
+const fetchRetry = async (request: Request, config): Promise<Response> => {
+	const { retries, retryDelay, retryOn } = config.retryConfig as RequestInitRetryParams
+
+	delete config.abortController
+
+	return new Promise((resolve, reject) => {
+		const retry = async (attempt: number, response: Response) => {
+			response.json = async () => json.parse(await response.clone().text())
+
+			const delay =
+				typeof retryDelay === "function" ? retryDelay(attempt, response) : retryDelay
+
+			// beforeRetry hook
+			if (config?.hooks?.beforeRetry) {
+				await config.hooks.beforeRetry(request, response, attempt, delay)
+			}
+
+			setTimeout(() => wrappedFetch(++attempt), delay)
+		}
+
+		const wrappedFetch = async (attempt) => {
+			try {
+				const response = await _fetch(request, config)
+
+				// afterResponse hook
+				if (config?.hooks?.afterResponse) {
+					response.json = async () => json.parse(await response.clone().text())
+					await config.hooks.afterResponse(request, response, config)
+				}
+
+				const shouldRetry = () => {
+					if (Array.isArray(retryOn) && retryOn.indexOf(response.status) === -1) {
+						resolve(response)
+					} else if (typeof retryOn === "function") {
+						try {
+							response.json = async () => json.parse(await response.clone().text())
+							Promise.resolve(retryOn(attempt, response))
+								.then((retryOnResponse) => {
+									retryOnResponse ? retry(attempt, response) : resolve(response)
+								})
+								.catch(reject)
+						} catch (error) {
+							reject(error)
+						}
+					} else {
+						attempt < retries ? retry(attempt, response) : resolve(response)
+					}
+				}
+
+				shouldRetry()
+			} catch (error) {
+				reject(error)
+			}
+		}
+
+		wrappedFetch(0)
+	})
+}
+
+export default fetchRetry

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ import type {
 	XOR,
 } from "./types"
 import { isEmpty, setHeaders, mergeConfigs, filterRequestOptions } from "./utils"
-import timeout from "./utils/timeout"
 import json from "./utils/json-parse"
 import { HTTPError } from "./utils/errors"
+import fetchRetry from "./core/fetchRetry"
 
 // All the HTTP request methods.
 const methods = ["get", "head", "put", "delete", "post", "patch", "options"] as const
@@ -35,18 +35,6 @@ const _request = (config): Request => {
 	return new Request(config.url.toString(), request)
 }
 
-const _fetch = async (request: Request, config) => {
-	if (config?.hooks?.beforeRequest) {
-		await config.hooks.beforeRequest(request)
-	}
-
-	if (config.timeout === false) {
-		return await fetch(request.clone())
-	}
-
-	return timeout(request.clone(), config.abortController, config.timeout)
-}
-
 /**
  * HttpAdapter make http requests 🦅.
  *
@@ -56,16 +44,7 @@ const httpAdapter = async (config: Options, method: HttpMethod, methodConfig: Me
 	const _config = mergeConfigs(config, methodConfig, method)
 	const request = _request(_config)
 
-	const response = await _fetch(request, _config)
-
-	// Still under development
-	if (config?.hooks?.afterResponse) {
-		delete _config.abortController
-
-		response.json = async () => json.parse(await response.clone().text())
-
-		await config.hooks.afterResponse(request, response, _config)
-	}
+	const response = await fetchRetry(request, _config)
 
 	// non-2xx HTTP responses into errors:
 	if (!response.ok) {
@@ -228,6 +207,16 @@ const create = <T extends ServiceConfig>(config?: T) => {
 					serviceConfig.hooks = {}
 					serviceConfig.hooks.afterResponse = fn
 				},
+				beforeRetry: (fn) => {
+					if (serviceConfig?.hooks?.beforeRetry) {
+						throw new TypeError(
+							"beforeRetry has already been invoked within configuration.",
+						)
+					}
+
+					serviceConfig.hooks = {}
+					serviceConfig.hooks.beforeRetry = fn
+				},
 				setHeaders: (newHeaders) =>
 					setHeaders((serviceConfig.headers = serviceConfig.headers || {}), newHeaders),
 			},
@@ -243,6 +232,7 @@ const create = <T extends ServiceConfig>(config?: T) => {
 				...instances[Object.keys(instances)[0]],
 				beforeRequest: (fn) => forEachInstance((instance) => instance.beforeRequest(fn)),
 				afterResponse: (fn) => forEachInstance((instance) => instance.afterResponse(fn)),
+				beforeRetry: (fn) => forEachInstance((instance) => instance.beforeRetry(fn)),
 				setHeaders: (newHeaders) =>
 					forEachInstance((instance) => instance.setHeaders(newHeaders)),
 			}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -28,3 +28,10 @@ export class TimeoutError extends Error {
 		this.request = request
 	}
 }
+
+export class ArgumentError extends Error {
+	constructor(message) {
+		super(message)
+		this.name = "ArgumentError"
+	}
+}


### PR DESCRIPTION
Introduce a flexible `retry` option to enhance the resilience of the HTTP client. Users can now configure the number of retries and intervals between retries.